### PR TITLE
[CRB-211] Treat the transaction payload as bytes, not a UTF-8 string

### DIFF
--- a/validator/src/ffi.rs
+++ b/validator/src/ffi.rs
@@ -15,7 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-pub use cpython::{ObjectProtocol, PyClone, PyObject, PyString, Python};
+pub use cpython::{ObjectProtocol, PyBytes, PyClone, PyObject, PyString, Python};
 
 #[no_mangle]
 pub unsafe extern "C" fn ffi_reclaim_string(s_ptr: *mut u8, s_len: usize, s_cap: usize) -> isize {
@@ -44,7 +44,7 @@ pub fn py_import_class(module: &str, class: &str) -> PyObject {
         .unwrap_or_else(|_| panic!("Unable to import {} from '{}'", class, module))
 }
 
-pub fn py_import_class_static_attr(module: &str, class: &str, attr: &str) -> PyString {
+pub fn py_import_class_static_attr(module: &str, class: &str, attr: &str) -> PyBytes {
     let gil = Python::acquire_gil();
     let python = gil.python();
     python
@@ -54,6 +54,6 @@ pub fn py_import_class_static_attr(module: &str, class: &str, attr: &str) -> PyS
         .unwrap_or_else(|_| panic!("Unable to import {} from '{}'", class, module))
         .getattr(python, attr)
         .unwrap()
-        .repr(python)
+        .extract(python)
         .unwrap()
 }

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -20,7 +20,6 @@
 use crate::batch::Batch;
 use crate::block::Block;
 use crate::execution::execution_platform::{ExecutionPlatform, NULL_STATE_HASH};
-use crate::ffi;
 use crate::gossip::permission_verifier::PermissionVerifier;
 use crate::journal::block_scheduler::BlockScheduler;
 use crate::journal::chain_commit_state::{
@@ -32,7 +31,6 @@ use crate::journal::{block_manager::BlockManager, block_wrapper::BlockStatus};
 use crate::scheduler::TxnExecutionResult;
 use crate::state::{settings_view::SettingsView, state_view_factory::StateViewFactory};
 
-use lazy_static::lazy_static;
 use log::{error, info, warn};
 use std::sync::{
     atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -42,13 +40,7 @@ use std::sync::{
 use std::thread;
 use std::time::Duration;
 
-lazy_static! {
-    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyBytes = ffi::py_import_class_static_attr(
-        "sawtooth_validator.journal.batch_injector",
-        "GluwaBatchInjector",
-        "housekeeping_payload"
-    );
-}
+use super::candidate_block::PY_GLUWA_BATCH_INJECTOR_PAYLOAD;
 
 const BLOCKVALIDATION_QUEUE_RECV_TIMEOUT: u64 = 100;
 

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -43,7 +43,7 @@ use std::thread;
 use std::time::Duration;
 
 lazy_static! {
-    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyString = ffi::py_import_class_static_attr(
+    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyBytes = ffi::py_import_class_static_attr(
         "sawtooth_validator.journal.batch_injector",
         "GluwaBatchInjector",
         "housekeeping_payload"
@@ -732,13 +732,13 @@ impl BlockValidation for OnChainRulesValidation {
                 let gil = cpython::Python::acquire_gil();
                 let py = gil.python();
 
-                let injector_payload = PY_GLUWA_BATCH_INJECTOR_PAYLOAD.to_string(py).unwrap();
+                let injector_payload = PY_GLUWA_BATCH_INJECTOR_PAYLOAD.data(py);
                 let invalid_housekeeping = block.batches[1..]
                     .iter()
                     .map(|batch| batch.transactions.iter())
                     .flatten()
                     .find(|txn| {
-                        String::from_utf8(txn.payload.clone()).expect("utf8") == injector_payload
+                        txn.payload == injector_payload
                     })
                     .and_then(|_| Some(()));
 

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -38,7 +38,7 @@ use crate::scheduler::Scheduler;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyString = ffi::py_import_class_static_attr(
+    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: cpython::PyBytes = ffi::py_import_class_static_attr(
         "sawtooth_validator.journal.batch_injector",
         "GluwaBatchInjector",
         "housekeeping_payload"
@@ -284,14 +284,13 @@ impl CandidateBlock {
                         let py = gil.python();
 
                         let injector_payload =
-                            PY_GLUWA_BATCH_INJECTOR_PAYLOAD.to_string(py).unwrap();
+                            PY_GLUWA_BATCH_INJECTOR_PAYLOAD.data(py);
 
                         if let Some(..) = batch
                             .transactions
                             .iter()
                             .find(|txn| {
-                                String::from_utf8(txn.payload.clone()).expect("utf8")
-                                    == injector_payload
+                                txn.payload == injector_payload
                             })
                             .and_then(|_| Some(true))
                         {

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -38,7 +38,7 @@ use crate::scheduler::Scheduler;
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: cpython::PyBytes = ffi::py_import_class_static_attr(
+    pub static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyBytes = ffi::py_import_class_static_attr(
         "sawtooth_validator.journal.batch_injector",
         "GluwaBatchInjector",
         "housekeeping_payload"

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -39,7 +39,6 @@ use crate::block::Block;
 use crate::consensus::notifier::ConsensusNotifier;
 use crate::consensus::registry::ConsensusRegistry;
 use crate::execution::execution_platform::ExecutionPlatform;
-use crate::ffi;
 use crate::gossip::permission_verifier::PermissionVerifier;
 use crate::journal;
 use crate::journal::block_manager::{BlockManager, BlockManagerError, BlockRef};
@@ -59,13 +58,7 @@ use crate::state::state_view_factory::StateViewFactory;
 use lazy_static::lazy_static;
 use log::{debug, error, info, warn};
 
-lazy_static! {
-    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyBytes = ffi::py_import_class_static_attr(
-        "sawtooth_validator.journal.batch_injector",
-        "GluwaBatchInjector",
-        "housekeeping_payload"
-    );
-}
+use super::candidate_block::PY_GLUWA_BATCH_INJECTOR_PAYLOAD;
 
 const RECV_TIMEOUT_MILLIS: u64 = 100;
 

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -60,7 +60,7 @@ use lazy_static::lazy_static;
 use log::{debug, error, info, warn};
 
 lazy_static! {
-    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyString = ffi::py_import_class_static_attr(
+    static ref PY_GLUWA_BATCH_INJECTOR_PAYLOAD: ffi::PyBytes = ffi::py_import_class_static_attr(
         "sawtooth_validator.journal.batch_injector",
         "GluwaBatchInjector",
         "housekeeping_payload"
@@ -205,10 +205,9 @@ impl ChainControllerState {
                         let first_batch = block.batches.iter().next().expect("first batch");
                         let first_transaction =
                             first_batch.transactions.iter().next().expect("first txn");
-                        let bytes = first_transaction.payload.clone();
-                        String::from_utf8(bytes).expect("txn payload")
+                        &first_transaction.payload
                     };
-                    let bool = payload == PY_GLUWA_BATCH_INJECTOR_PAYLOAD.to_string(py).unwrap();
+                    let bool = payload == PY_GLUWA_BATCH_INJECTOR_PAYLOAD.data(py);
                     let starting_idx = match bool {
                         true => 1,
                         false => 0,


### PR DESCRIPTION
The housekeeping payload is a sequence of bytes (the [bytes type](https://docs.python.org/3/library/stdtypes.html#bytes-objects) in python). Previously we were treating the payload as a string. Due to the fact that all Rust strings must be valid UTF-8, and the sequence of bytes in the payload is _not_ valid UTF-8, we see errors on conversion.

This PR treats the payload as bytes, which avoids the error and also allows us to remove a few extra `clone`s, as the payload contents can now be borrowed. We also remove the duplicated statics for the batch injector payload, as we only need one.