### PR TITLE
Fixing various issues with block verification

### DIFF
--- a/protos/client_block.proto
+++ b/protos/client_block.proto
@@ -63,6 +63,30 @@ message ClientBlockListResponse {
     ClientPagingResponse paging = 4;
 }
 
+//custom message to request signatures from validators to be rewarded.
+message ClientRewardBlockListRequest {
+    string head_id = 1;
+    uint64 first_predecessor_height = 2;
+    uint64 last_predecessor_height = 3;
+}
+
+//blocks in descending order
+message ClientRewardBlockListResponse {
+    enum Status {
+        STATUS_UNSET = 0;
+        OK = 1;
+        INTERNAL_ERROR = 2;
+        NOT_READY = 3;
+        NO_ROOT = 4;
+        NO_RESOURCE = 5;
+        INVALID_ID = 8;
+    }
+
+    Status status = 1;
+    repeated Block blocks = 2;
+    string head_id = 3;
+}
+
 // A request to return a specific block from the validator. The block must be
 // specified by its unique id, in this case the block's header signature
 message ClientBlockGetByIdRequest {

--- a/protos/processor.proto
+++ b/protos/processor.proto
@@ -124,7 +124,11 @@ message TpProcessRequest {
     // Controlled by a flag during transaction processor registration.
     bytes header_bytes = 5;
 
-    uint64 tip = 6; // The block number
+    // The block number
+    uint64 tip = 6;
+
+    // The signature of the block to be processed
+    string block_signature = 7;
 }
 
 

--- a/protos/validator.proto
+++ b/protos/validator.proto
@@ -115,6 +115,10 @@ message Message {
         CLIENT_STATUS_GET_REQUEST = 129;
         // A response with the validator's status
         CLIENT_STATUS_GET_RESPONSE = 130;
+        // A request for reward blocks
+        CLIENT_REWARD_BLOCK_LIST_REQUEST = 131;
+        //A response for reward blocks
+        CLIENT_REWARD_BLOCK_LIST_RESPONSE = 132;
 
         // Message types for events
         CLIENT_EVENTS_SUBSCRIBE_REQUEST = 500;

--- a/validator/sawtooth_validator/journal/batch_injector.py
+++ b/validator/sawtooth_validator/journal/batch_injector.py
@@ -115,7 +115,7 @@ class GluwaBatchInjector(BatchInjector):
 
     def block_start(self, previous_block):
         pub_key = self._signer.get_public_key().as_hex()
-        version = '1.7'
+        version = '2.0'
         ns = '8a1a04'
         payload = GluwaBatchInjector.housekeeping_payload
         tx_header = TransactionHeader(

--- a/validator/sawtooth_validator/networking/handlers.py
+++ b/validator/sawtooth_validator/networking/handlers.py
@@ -69,13 +69,19 @@ class ConnectHandler(Handler):
         """
         result = urlparse(endpoint)
         hostname = result.hostname
-        if hostname is None:
+        port = None
+        try:
+            port = result.port
+        except:
+            pass
+        if hostname is None or port is None:
             return False
-
-        for interface in interfaces:
-            if interface == hostname:
+        else:
+            for interface in interfaces:
+                if interface == hostname:
+                    return False
+            if hostname == 'localhost' or hostname == '127.0.0.1' or hostname == 'insert.your.ip':
                 return False
-
         return True
 
     def handle(self, connection_id, message_content):

--- a/validator/sawtooth_validator/server/state_verifier.py
+++ b/validator/sawtooth_validator/server/state_verifier.py
@@ -22,6 +22,9 @@ from sawtooth_validator.state.merkle import INIT_ROOT_KEY
 from sawtooth_validator.execution import tp_state_handlers
 from sawtooth_validator.execution import processor_handlers
 
+from sawtooth_validator.state import client_handlers
+from sawtooth_validator.networking.handlers import PingResponseHandler
+
 from sawtooth_validator.concurrent.threadpool import \
     InstrumentedThreadPoolExecutor
 from sawtooth_validator.execution.context_manager import ContextManager
@@ -165,6 +168,23 @@ def verify_state(global_state_db, blockstore, bind_component, scheduler_type):
         validator_pb2.Message.TP_UNREGISTER_REQUEST,
         processor_handlers.ProcessorUnRegisterHandler(
             transaction_executor.processor_manager),
+        component_thread_pool)
+
+    component_dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_STATE_LIST_REQUEST,
+        client_handlers.StateListRequest(
+            global_state_db,
+            blockstore),
+        component_thread_pool)
+
+    component_dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_BLOCK_GET_BY_NUM_REQUEST,
+        client_handlers.BlockGetByNumRequest(blockstore),
+        component_thread_pool)
+
+    component_dispatcher.add_handler(
+        validator_pb2.Message.PING_RESPONSE,
+        PingResponseHandler(),
         component_thread_pool)
 
     component_dispatcher.start()

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -699,7 +699,17 @@ class StateListRequest(_ClientRequestHandler):
 
     def _respond(self, request):
         if request.state_root != '':
-            self._validate_state_root(request.state_root)
+            if request.state_root.startswith('#'):
+                block_num_str = request.state_root[1:]
+                try:
+                    block_num = int(block_num_str)
+                    block = self._block_store.get_block_by_number(block_num)
+                    request.state_root = block.header.state_root_hash
+                except ValueError:
+                    request.state_root = ''
+
+            if request.state_root != '':
+                self._validate_state_root(request.state_root)
         state_root = self._set_root(request)
 
         # Fetch entries and encode as protobuf


### PR DESCRIPTION
To fix block verification in sawtooth 1.2 - the following PRs are all related and should be reviewed and merged together:
CRB-236/sdk-accepts-block-num-for-list-by-prefix
CRB-236/validator-fixes-block-verification
CRB-236/tp-fixes-block-verification
CRB-236/core-updating-tx-version
