### PR TITLE
[CRB-262] Implement reward block list request

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -443,7 +443,8 @@ class TransactionExecutor:
 
     def create_scheduler(self,
                          first_state_root,
-                         always_persist=False):
+                         always_persist=False,
+                         block_signature=None):
 
         # Useful for a logical first state root of ""
         if not first_state_root:
@@ -453,12 +454,14 @@ class TransactionExecutor:
             scheduler = SerialScheduler(
                 squash_handler=self._context_manager.get_squash_handler(),
                 first_state_hash=first_state_root,
-                always_persist=always_persist)
+                always_persist=always_persist,
+                block_signature=block_signature)
         elif self._scheduler_type == "parallel":
             scheduler = ParallelScheduler(
                 squash_handler=self._context_manager.get_squash_handler(),
                 first_state_hash=first_state_root,
-                always_persist=always_persist)
+                always_persist=always_persist,
+                block_signature=block_signature)
 
         else:
             raise AssertionError(

--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -308,7 +308,8 @@ class TransactionExecutorThread:
                 signature=txn.header_signature,
                 context_id=context_id,
                 header_bytes=txn.header,
-                tip=txn_info.tip
+                tip=txn_info.tip,
+                block_signature=self._scheduler.block_signature
                 )
 
             # Since we have already checked if the transaction should be failed

--- a/validator/sawtooth_validator/execution/scheduler_parallel.py
+++ b/validator/sawtooth_validator/execution/scheduler_parallel.py
@@ -455,7 +455,7 @@ class PredecessorChain:
 
 
 class ParallelScheduler(Scheduler):
-    def __init__(self, squash_handler, first_state_hash, always_persist):
+    def __init__(self, squash_handler, first_state_hash, always_persist, block_signature=None):
         self._squash = squash_handler
         self._first_state_hash = first_state_hash
         self._last_state_hash = first_state_hash
@@ -505,6 +505,11 @@ class ParallelScheduler(Scheduler):
         self._cancelled = False
         self._final = False
         self.tip = None
+        self._block_signature = block_signature
+    
+    @property
+    def block_signature(self):
+        return self._block_signature
 
     def _find_input_dependencies(self, inputs):
         """Use the predecessor tree to find dependencies based on inputs.

--- a/validator/sawtooth_validator/execution/scheduler_serial.py
+++ b/validator/sawtooth_validator/execution/scheduler_serial.py
@@ -46,7 +46,7 @@ class SerialScheduler(Scheduler):
     schedulers - for tests related to performance, correctness, etc.
     """
 
-    def __init__(self, squash_handler, first_state_hash, always_persist):
+    def __init__(self, squash_handler, first_state_hash, always_persist, block_signature=None):
         self._txn_queue = deque()
         self._scheduled_transactions = []
         self._batch_statuses = {}
@@ -69,6 +69,11 @@ class SerialScheduler(Scheduler):
         self._required_state_hashes = {}
         self._already_calculated = False
         self._always_persist = always_persist
+        self._block_signature = block_signature
+    
+    @property
+    def block_signature(self):
+        return self._block_signature
 
     def __del__(self):
         self.cancel()

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -181,6 +181,11 @@ def add(
         client_thread_pool)
 
     dispatcher.add_handler(
+        validator_pb2.Message.CLIENT_REWARD_BLOCK_LIST_REQUEST,
+        client_handlers.RewardListRequest(block_store, completer.block_cache),
+        client_thread_pool)
+
+    dispatcher.add_handler(
         validator_pb2.Message.CLIENT_BLOCK_GET_BY_ID_REQUEST,
         client_handlers.BlockGetByIdRequest(block_store),
         client_thread_pool)

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -182,7 +182,7 @@ def add(
 
     dispatcher.add_handler(
         validator_pb2.Message.CLIENT_REWARD_BLOCK_LIST_REQUEST,
-        client_handlers.RewardListRequest(block_store, completer.block_cache),
+        client_handlers.RewardListRequest(block_store, completer._block_manager),
         client_thread_pool)
 
     dispatcher.add_handler(

--- a/validator/sawtooth_validator/server/state_verifier.py
+++ b/validator/sawtooth_validator/server/state_verifier.py
@@ -262,7 +262,8 @@ def process_blocks(
                 block_num=block.block_num,
                 transaction_executor=transaction_executor,
                 context_manager=context_manager,
-                batches=block.batches)
+                batches=block.batches,
+                block_signature=block.header_signature)
 
             if new_root != block.state_root_hash:
                 raise InvalidChainError(
@@ -277,11 +278,13 @@ def execute_batches(
     block_num,
     transaction_executor,
     context_manager,
-    batches
+    batches,
+    block_signature
 ):
     scheduler = transaction_executor.create_scheduler(
         previous_state_root,
-        always_persist=True)
+        always_persist=True,
+        block_signature=block_signature)
 
     transaction_executor.execute(scheduler)
 

--- a/validator/src/execution/execution_platform.rs
+++ b/validator/src/execution/execution_platform.rs
@@ -23,5 +23,9 @@ use crate::{block::Block, scheduler::Scheduler};
 pub const NULL_STATE_HASH: &str = "";
 
 pub trait ExecutionPlatform: Sync + Send {
-    fn create_scheduler(&self, state_hash: &str, block: Option<&Block>) -> Result<Box<dyn Scheduler>, cpython::PyErr>;
+    fn create_scheduler(
+        &self,
+        state_hash: &str,
+        block: Option<&Block>,
+    ) -> Result<Box<dyn Scheduler>, cpython::PyErr>;
 }

--- a/validator/src/execution/execution_platform.rs
+++ b/validator/src/execution/execution_platform.rs
@@ -15,7 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-use crate::scheduler::Scheduler;
+use crate::{block::Block, scheduler::Scheduler};
 
 /// The logical state hash before state has been added to the
 /// merkle database. May not be the actual first state hash due to
@@ -23,5 +23,5 @@ use crate::scheduler::Scheduler;
 pub const NULL_STATE_HASH: &str = "";
 
 pub trait ExecutionPlatform: Sync + Send {
-    fn create_scheduler(&self, state_hash: &str) -> Result<Box<dyn Scheduler>, cpython::PyErr>;
+    fn create_scheduler(&self, state_hash: &str, block: Option<&Block>) -> Result<Box<dyn Scheduler>, cpython::PyErr>;
 }

--- a/validator/src/execution/py_executor.rs
+++ b/validator/src/execution/py_executor.rs
@@ -34,12 +34,17 @@ impl PyExecutor {
 }
 
 impl ExecutionPlatform for PyExecutor {
-    fn create_scheduler(&self, state_hash: &str, block: Option<&Block>) -> Result<Box<dyn Scheduler>, cpython::PyErr> {
+    fn create_scheduler(
+        &self,
+        state_hash: &str,
+        block: Option<&Block>,
+    ) -> Result<Box<dyn Scheduler>, cpython::PyErr> {
         let gil = cpython::Python::acquire_gil();
         let py = gil.python();
         let kwargs = block.map(|block| {
             let dict = PyDict::new(py);
-            dict.set_item(py, "block_signature", block.header_signature.clone()).unwrap();
+            dict.set_item(py, "block_signature", block.header_signature.clone())
+                .unwrap();
             dict
         });
         let scheduler = self

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -493,7 +493,7 @@ impl<TEP: ExecutionPlatform> BlockValidation for BatchesInBlockValidation<TEP> {
         let state_root = previous_state_root.unwrap_or(&null_state_hash);
         let mut scheduler = self
             .transaction_executor
-            .create_scheduler(state_root)
+            .create_scheduler(state_root, Some(block))
             .map_err(|err| {
                 ValidationError::BlockValidationError(format!(
                     "Error during validation of block {} batches: {:?}",

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -729,9 +729,7 @@ impl BlockValidation for OnChainRulesValidation {
                     .iter()
                     .map(|batch| batch.transactions.iter())
                     .flatten()
-                    .find(|txn| {
-                        txn.payload == injector_payload
-                    })
+                    .find(|txn| txn.payload == injector_payload)
                     .and_then(|_| Some(()));
 
                 if let Some(..) = invalid_housekeeping {

--- a/validator/src/journal/candidate_block.rs
+++ b/validator/src/journal/candidate_block.rs
@@ -283,15 +283,12 @@ impl CandidateBlock {
                         let gil = cpython::Python::acquire_gil();
                         let py = gil.python();
 
-                        let injector_payload =
-                            PY_GLUWA_BATCH_INJECTOR_PAYLOAD.data(py);
+                        let injector_payload = PY_GLUWA_BATCH_INJECTOR_PAYLOAD.data(py);
 
                         if let Some(..) = batch
                             .transactions
                             .iter()
-                            .find(|txn| {
-                                txn.payload == injector_payload
-                            })
+                            .find(|txn| txn.payload == injector_payload)
                             .and_then(|_| Some(true))
                         {
                             debug!("Ignoring unneeded housekeeping batch: {:?}", batch);

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -287,7 +287,7 @@ impl SyncBlockPublisher {
 
             let scheduler = state
                 .transaction_executor
-                .create_scheduler(&previous_block.state_root_hash)
+                .create_scheduler(&previous_block.state_root_hash, None)
                 .expect("Failed to create new scheduler");
 
             let committed_txn_cache = TransactionCommitCache::new(self.commit_store.clone());

--- a/validator/src/state/merkle.rs
+++ b/validator/src/state/merkle.rs
@@ -996,7 +996,8 @@ mod tests {
             }
 
             // perform some deletions on the upper keys
-            let delete_items = (500..1000).choose_multiple(&mut rng, 50)
+            let delete_items = (500..1000)
+                .choose_multiple(&mut rng, 50)
                 .into_iter()
                 .map(|i| hex_hash(format!("{:016x}", i).as_bytes()))
                 .collect::<Vec<String>>();


### PR DESCRIPTION
The handler itself is essentially copy-pasted from CC 1.7 (that part of sawtooth didn't change much between 1.0.5 and 1.2). The rest of the PR threads through the `block_signature` to pass to the TP during validation. This was not yet ported from CC 1.7, which is why we haven't run into problems in testing up to this point.