### PR TITLE
[CRB-282] Only notify scheduler when block is successfully validated

### DIFF
--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -714,11 +714,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
                 block.header_signature, result.status,
             ),
         }
-
-        match self.notify_block_validation_results_received(&block) {
-            Ok(_) => (),
-            Err(err) => warn!("{:?}", err),
-        }
     }
 
     fn handle_block_commit(&mut self, block: &Block) -> Result<(), ChainControllerError> {
@@ -894,6 +889,10 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
                 }
 
                 // Updated the block, so we're done
+                match self.notify_block_validation_results_received(&block) {
+                    Ok(_) => (),
+                    Err(err) => warn!("{:?}", err),
+                }
                 break;
             }
         }

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -888,11 +888,14 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
                     state.state_pruning_manager.execute(prune_at)
                 }
 
-                // Updated the block, so we're done
-                match self.notify_block_validation_results_received(&block) {
+                // Notify scheduler that the block is complete, so dependent blocks
+                // can begin validation
+                match self.notify_block_committed(&block) {
                     Ok(_) => (),
                     Err(err) => warn!("{:?}", err),
                 }
+
+                // Updated the block, so we're done
                 break;
             }
         }
@@ -921,10 +924,7 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
         }
     }
 
-    fn notify_block_validation_results_received(
-        &self,
-        block: &Block,
-    ) -> Result<(), ChainControllerError> {
+    fn notify_block_committed(&self, block: &Block) -> Result<(), ChainControllerError> {
         let sender = self
             .validation_result_sender
             .as_ref()

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -674,6 +674,7 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
     }
 
     fn on_block_validated(&self, block: &Block, result: &BlockValidationResult) {
+        log::trace!("on_block_validated: {}, {:?}", block, result);
         let mut blocks_considered_count =
             COLLECTOR.counter("ChainController.blocks_considered_count", None, None);
         blocks_considered_count.inc();
@@ -686,6 +687,13 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
                 // for (moved into chain head in case of commit, dropped otherwise)
                 self.consensus_notifier
                     .notify_block_valid(&block.header_signature);
+
+                // Notify scheduler that the block is complete, so dependent blocks
+                // can begin validation
+                match self.notify_block_committed(&block) {
+                    Ok(_) => (),
+                    Err(err) => warn!("{:?}", err),
+                }
             }
             BlockStatus::Invalid => {
                 self.consensus_notifier
@@ -886,13 +894,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
 
                     // Execute pruning:
                     state.state_pruning_manager.execute(prune_at)
-                }
-
-                // Notify scheduler that the block is complete, so dependent blocks
-                // can begin validation
-                match self.notify_block_committed(&block) {
-                    Ok(_) => (),
-                    Err(err) => warn!("{:?}", err),
                 }
 
                 // Updated the block, so we're done

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -690,7 +690,7 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
 
                 // Notify scheduler that the block is complete, so dependent blocks
                 // can begin validation
-                match self.notify_block_committed(&block) {
+                match self.notify_received_valid_result(&block) {
                     Ok(_) => (),
                     Err(err) => warn!("{:?}", err),
                 }
@@ -925,7 +925,7 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
         }
     }
 
-    fn notify_block_committed(&self, block: &Block) -> Result<(), ChainControllerError> {
+    fn notify_received_valid_result(&self, block: &Block) -> Result<(), ChainControllerError> {
         let sender = self
             .validation_result_sender
             .as_ref()


### PR DESCRIPTION
Currently, the block validator notifies the block scheduler unconditionally, regardless of whether a block was found to be invalid or valid. This causes the scheduler to begin the execution of the dependent blocks, even if the block failed. This contributes to missing state errors because in the case of failure the state root is not present in the database.