### PR TITLE
[CRB-283] Prevent block results from being prematurely evicted from the result store

### DIFF
--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -98,7 +98,7 @@ impl BlockValidationResultStore {
             self.in_progress_blocks
                 .lock()
                 .expect("The mutex is poisoned")
-                .insert(result.block_id)
+                .insert(result.block_id);
         }
     }
 

--- a/validator/src/journal/chain.rs
+++ b/validator/src/journal/chain.rs
@@ -552,17 +552,15 @@ impl<TEP: ExecutionPlatform + Clone + 'static, PV: PermissionVerifier + Clone + 
             .block_validation_results
             .get(&block.header_signature)
             .is_some()
+            || self
+                .block_validation_results
+                .is_in_progress(&block.header_signature)
         {
             return;
         }
 
-        // Create block validation result, maked as in-validation
-        self.block_validation_results.insert(BlockValidationResult {
-            block_id: block.header_signature.clone(),
-            execution_results: vec![],
-            num_transactions: 0,
-            status: BlockStatus::InValidation,
-        });
+        self.block_validation_results
+            .mark_in_progress(block.header_signature.clone());
 
         // Submit for validation
         let sender = self.validation_result_sender.as_ref().expect(


### PR DESCRIPTION
Currently, as soon as blocks are complete they are added to the execution result store with a status of "in progress". The result store has a bounded capacity of 512 entries, which means that if more than 512 blocks are pending validation entries will be evicted prematurely. This manifests as errors during block commit, as when the block is committed the results are missing from the store.

This PR tracks in progress blocks separately, so as not to fill the cache and to prevent unnecessary evictions.