### PR TITLE
[CRB-285] Always pass a block ID to the TP to prevent invalid lookups

### DIFF
--- a/validator/sawtooth_validator/execution/executor.py
+++ b/validator/sawtooth_validator/execution/executor.py
@@ -310,7 +310,7 @@ class TransactionExecutorThread:
                 header_bytes=txn.header,
                 tip=txn_info.tip,
                 block_signature=self._scheduler.block_signature
-                )
+            )
 
             # Since we have already checked if the transaction should be failed
             # all other cases should either be executed or waited for.
@@ -444,8 +444,8 @@ class TransactionExecutor:
 
     def create_scheduler(self,
                          first_state_root,
-                         always_persist=False,
-                         block_signature=None):
+                         previous_block_id,
+                         always_persist=False):
 
         # Useful for a logical first state root of ""
         if not first_state_root:
@@ -456,13 +456,13 @@ class TransactionExecutor:
                 squash_handler=self._context_manager.get_squash_handler(),
                 first_state_hash=first_state_root,
                 always_persist=always_persist,
-                block_signature=block_signature)
+                block_signature=previous_block_id)
         elif self._scheduler_type == "parallel":
             scheduler = ParallelScheduler(
                 squash_handler=self._context_manager.get_squash_handler(),
                 first_state_hash=first_state_root,
                 always_persist=always_persist,
-                block_signature=block_signature)
+                block_signature=previous_block_id)
 
         else:
             raise AssertionError(

--- a/validator/sawtooth_validator/server/component_handlers.py
+++ b/validator/sawtooth_validator/server/component_handlers.py
@@ -164,7 +164,7 @@ def add(
         validator_pb2.Message.CLIENT_STATE_LIST_REQUEST,
         client_handlers.StateListRequest(
             merkle_db,
-            block_store),
+            block_store, completer._block_manager),
         client_thread_pool)
 
     dispatcher.add_handler(

--- a/validator/sawtooth_validator/server/state_verifier.py
+++ b/validator/sawtooth_validator/server/state_verifier.py
@@ -263,7 +263,7 @@ def process_blocks(
                 transaction_executor=transaction_executor,
                 context_manager=context_manager,
                 batches=block.batches,
-                block_signature=block.header_signature)
+                block_signature=block.previous_block_id)
 
             if new_root != block.state_root_hash:
                 raise InvalidChainError(
@@ -279,12 +279,12 @@ def execute_batches(
     transaction_executor,
     context_manager,
     batches,
-    block_signature
+    previous_block_id
 ):
     scheduler = transaction_executor.create_scheduler(
         previous_state_root,
-        always_persist=True,
-        block_signature=block_signature)
+        previous_block_id,
+        always_persist=True)
 
     transaction_executor.execute(scheduler)
 

--- a/validator/src/execution/execution_platform.rs
+++ b/validator/src/execution/execution_platform.rs
@@ -26,6 +26,6 @@ pub trait ExecutionPlatform: Sync + Send {
     fn create_scheduler(
         &self,
         state_hash: &str,
-        block: Option<&Block>,
+        previous_block_id: &str,
     ) -> Result<Box<dyn Scheduler>, cpython::PyErr>;
 }

--- a/validator/src/execution/py_executor.rs
+++ b/validator/src/execution/py_executor.rs
@@ -37,20 +37,19 @@ impl ExecutionPlatform for PyExecutor {
     fn create_scheduler(
         &self,
         state_hash: &str,
-        block: Option<&Block>,
+        previous_block_id: &str,
     ) -> Result<Box<dyn Scheduler>, cpython::PyErr> {
         let gil = cpython::Python::acquire_gil();
         let py = gil.python();
-        let kwargs = block.map(|block| {
-            let dict = PyDict::new(py);
-            dict.set_item(py, "block_signature", block.header_signature.clone())
-                .unwrap();
-            dict
-        });
         let scheduler = self
             .executor
-            .call_method(py, "create_scheduler", (state_hash,), kwargs.as_ref())
-            .expect(
+            .call_method(
+                py,
+                "create_scheduler",
+                (state_hash, previous_block_id),
+                None,
+            )
+            .expect_pyerr(
                 "no method create_scheduler on sawtooth_validator.execution.py_executor.PyExecutor",
             );
         Ok(Box::new(PyScheduler::new(scheduler)))

--- a/validator/src/execution/py_executor.rs
+++ b/validator/src/execution/py_executor.rs
@@ -49,7 +49,7 @@ impl ExecutionPlatform for PyExecutor {
                 (state_hash, previous_block_id),
                 None,
             )
-            .expect_pyerr(
+            .expect(
                 "no method create_scheduler on sawtooth_validator.execution.py_executor.PyExecutor",
             );
         Ok(Box::new(PyScheduler::new(scheduler)))

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -493,7 +493,7 @@ impl<TEP: ExecutionPlatform> BlockValidation for BatchesInBlockValidation<TEP> {
         let state_root = previous_state_root.unwrap_or(&null_state_hash);
         let mut scheduler = self
             .transaction_executor
-            .create_scheduler(state_root, Some(block))
+            .create_scheduler(state_root, &block.previous_block_id)
             .map_err(|err| {
                 ValidationError::BlockValidationError(format!(
                     "Error during validation of block {} batches: {:?}",

--- a/validator/src/journal/publisher.rs
+++ b/validator/src/journal/publisher.rs
@@ -287,7 +287,10 @@ impl SyncBlockPublisher {
 
             let scheduler = state
                 .transaction_executor
-                .create_scheduler(&previous_block.state_root_hash, None)
+                .create_scheduler(
+                    &previous_block.state_root_hash,
+                    &previous_block.header_signature,
+                )
                 .expect("Failed to create new scheduler");
 
             let committed_txn_cache = TransactionCommitCache::new(self.commit_store.clone());


### PR DESCRIPTION
Currently we only pass a block ID to the TP in some cases, which means that sometimes the TP falls back to requesting a block by block number only. This is incorrect in the presence of forks and in Sawtooth 1.2 blocks are not guaranteed to be committed to the store by the time the following blocks are executed. This causes blocks to be incorrectly marked invalid.

This PR makes it so we always pass the previous block ID to the transaction processor. This is always valid because the TP should never need to look up the current block, so the previous block ID is enough to fetch the correct branch from the block manager. This makes the processor more deterministic and less reliant on the node's local state. Additionally, now the branch head ID can be passed to state list requests, which is necessary for housekeeping transactions to succeed.