### PR TITLE
[CRB-294] Don't treat no entries under a state prefix as an error

### DIFF
--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -730,12 +730,6 @@ class StateListRequest(_ClientRequestHandler):
             entries,
             self._status.INVALID_PAGING)
 
-        if entries is None:
-            return self._wrap_response(
-                self._status.NO_RESOURCE,
-                state_root=state_root,
-                paging=paging)
-
         return self._wrap_response(
             state_root=state_root,
             paging=paging,

--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -730,7 +730,7 @@ class StateListRequest(_ClientRequestHandler):
             entries,
             self._status.INVALID_PAGING)
 
-        if not entries:
+        if entries is None:
             return self._wrap_response(
                 self._status.NO_RESOURCE,
                 state_root=state_root,


### PR DESCRIPTION
Before this PR, when looking up states by prefix, we issue an error if there are no states. The filter operations in the TP expect a non-error response in this case.