### PR TITLE
CRB-215 Don't pollute the results cache with transitory status state InValidation. 

### DIFF
--- a/validator/src/journal/block_scheduler.rs
+++ b/validator/src/journal/block_scheduler.rs
@@ -141,10 +141,11 @@ impl<B: BlockStatusStore> BlockSchedulerState<B> {
 
                 let mut to_be_scheduled = vec![];
                 for predecessor in blocks_previous_to_previous {
-                    if self
-                        .block_status_store
-                        .status(&predecessor.header_signature)
-                        != BlockStatus::Unknown
+                    if self.contains(&predecessor.header_signature)
+                        || self
+                            .block_status_store
+                            .status(&predecessor.header_signature)
+                            != BlockStatus::Unknown
                     {
                         break;
                     }

--- a/validator/src/journal/block_scheduler.rs
+++ b/validator/src/journal/block_scheduler.rs
@@ -353,7 +353,7 @@ mod tests {
         );
 
         assert_eq!(
-            block_scheduler.done(&block_a.header_signature),
+            block_scheduler.done(&block_a.header_signature, false),
             vec![block_b.clone()],
             "Marking Block A as complete, makes Block B available"
         );
@@ -365,25 +365,25 @@ mod tests {
         );
 
         assert_eq!(
-            block_scheduler.done(&block_b.header_signature),
+            block_scheduler.done(&block_b.header_signature, false),
             vec![block_c1.clone(), block_c2.clone(), block_c3.clone()],
             "Marking Block B as complete, makes Block C1, C2, C3 available"
         );
 
         assert_eq!(
-            block_scheduler.done(&block_c2.header_signature),
+            block_scheduler.done(&block_c2.header_signature, false),
             vec![],
             "No Blocks are available"
         );
 
         assert_eq!(
-            block_scheduler.done(&block_c3.header_signature),
+            block_scheduler.done(&block_c3.header_signature, false),
             vec![],
             "No Blocks are available"
         );
 
         assert_eq!(
-            block_scheduler.done(&block_c1.header_signature),
+            block_scheduler.done(&block_c1.header_signature, false),
             vec![block_d1.clone(), block_d2.clone(), block_d3.clone()],
             "Blocks D1, D2, D3 are available"
         );

--- a/validator/src/journal/block_validator.rs
+++ b/validator/src/journal/block_validator.rs
@@ -84,13 +84,19 @@ impl BlockValidationResultStore {
     }
 
     pub fn fail_block(&self, block_id: &str) {
-        if let Some(ref mut result) = self
+        let mut cache = self
             .validation_result_cache
             .lock()
-            .expect("The mutex is poisoned")
-            .find(|r| r.block_id == block_id)
-        {
+            .expect("The mutex is poisoned");
+        if let Some(ref mut result) = cache.find(|r| r.block_id == block_id) {
             result.status = BlockStatus::Invalid
+        } else {
+            cache.insert(BlockValidationResult {
+                status: BlockStatus::Invalid,
+                block_id: block_id.into(),
+                execution_results: vec![],
+                num_transactions: 0,
+            });
         }
     }
 }


### PR DESCRIPTION
Depends on #54 and could replace #48 and #49

Don't validate a block if the block_validator already has the block scheduled for validation.
Don't insert 'invalidation' placeholders in the results cache when a block is scheduled for validation. Do not have created a special store as #48, ask the block_validator if the block is scheduled instead. Not extra data store managing, reuses original impl methods, less invasive, more maintainable; Comparing to the alternative solution: one extra sync read per results query, no extra sync insert/deletes writes to the extra InValidation store?
If a block_result is not found, look if the validator has it scheduled for processing; return 'InValidation' results instead of preemptively polluting the cache with an invalidation state upon initial validation scheduling.
When results are not available, predecessor traversal and conditional scheduling start; break when the block_validator has the first predecessor scheduled or results have been found.