### PR TITLE
[CRB-286] Adjust assertions for `RewardListRequest`s

### DIFF
--- a/validator/sawtooth_validator/state/client_handlers.py
+++ b/validator/sawtooth_validator/state/client_handlers.py
@@ -862,10 +862,10 @@ class RewardListRequest(_ClientRequestHandler):
             padding = head_block.block_num - b
 
             assert(0 < a)
-            assert(0 < delta)
+            assert(0 <= delta)
             assert(0 < padding)
-            INTERVAL_LIMIT = 20
-            assert(delta < INTERVAL_LIMIT)
+            # INTERVAL_LIMIT = 20
+            # assert(delta < INTERVAL_LIMIT)
             DEPTH_LIMIT = 10000
             #assert(padding < DEPTH_LIMIT)
             if DEPTH_LIMIT < padding:


### PR DESCRIPTION
The current assertions in RewardListRequest's handler do not hold when revalidating blocks from the production chain. This PR removes the interval limit check and adjusts the delta assertion so that old blocks can be revalidated.